### PR TITLE
Fix: properly handle student errors

### DIFF
--- a/src/gapper/core/unittest_wrapper/wrapper_def.py
+++ b/src/gapper/core/unittest_wrapper/wrapper_def.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from gapper.core.errors import (
     InternalError,
+    StudentError,
     SubmissionSyntaxError,
     TestFailedError,
 )
@@ -143,8 +144,10 @@ class TestCaseWrapper(TestCase, HookHolder):
             result.add_error(
                 SubmissionSyntaxError(e), set_failed=result.is_pass_status_unset
             )
-        except Exception as e:
+        except InternalError as e:
             result.add_error(InternalError(e), set_failed=result.is_pass_status_unset)
+        except Exception as e:
+            result.add_error(StudentError(e), set_failed=result.is_pass_status_unset)
         else:
             if result.is_pass_status_unset:
                 result.set_pass_status("passed")

--- a/src/gapper/core/unittest_wrapper/wrapper_def.py
+++ b/src/gapper/core/unittest_wrapper/wrapper_def.py
@@ -1,4 +1,5 @@
 """TestCaseWrapper and related helper definitions."""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
As-is, an error raised by the submitted code (such as a `NotImplementedError`) will be logged as an internal error, which is a bug. This fixes that by adding an additional error-catching case to check whether an error truly is internal or if it's the submission's fault. (We also now import `StudentError` to convey this.)